### PR TITLE
Show archives link only when more than 3 posts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Any content in this file will be included in the page.
 
 Alternately you can simply fork this repo and go from there.
 
+## Details
+
+- Really Simple will display up to three posts fully on the home page.
+
+- Link to archives in the header and at the end of the home page will only display when there are more than 3 posts that exists in `_posts`
+
+- The header has two links: `Archives` and `About`. Really Simple expects these files to be in the root project folder. The `jekyll new` command will create a dummy `about.md` file in the root folder. Remove the layout metadata so that the default template is used.
+
 ## Contributions
 Bug reports and pull requests are most welcome.
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Alternately you can simply fork this repo and go from there.
 
 - Really Simple will display up to three posts fully on the home page.
 
-- Link to archives in the header and at the end of the home page will only display when there are more than 3 posts that exists in `_posts`
+- Link to archives in the header and at the end of the home page will only display when there are more than 3 posts.
 
-- The header has two links: `Archives` and `About`. Really Simple expects these files to be in the root project folder. The `jekyll new` command will create a dummy `about.md` file in the root folder. Remove the layout metadata so that the default template is used.
+- The header has two links: `Archives` and `About`. Really Simple expects these files to be in the root project folder. The `jekyll new` command will create a dummy `about.md` file in the root folder. Remove the layout metadata so that the Really Simple default template is used.
 
 ## Contributions
 Bug reports and pull requests are most welcome.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,12 @@
    <div class="content">
       <div class="header">
          <a class="title" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
-         <span class="nav">&raquo; <a href="{{ "archives" | relative_url }}">archives</a> &nbsp;&raquo; <a href="{{ "about" | relative_url }}">about</a></span>
+         <span class="nav">
+            {% if site.posts.size > 3 %}
+            &raquo; <a href="{{ "archives" | relative_url }}">archives</a>
+            {% endif %}
+            &nbsp;&raquo; <a href="{{ "about" | relative_url }}">about</a>
+         </span>
       </div>
 
       {{ content }}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -21,5 +21,7 @@ layout: default
     {% endfor %}
   </ul>
 
+  {% if site.posts.size > 3 %}
   <a class="post-link" href="{{ "pages/archives" | relative_url }}">More...</a>
+  {% endif %}
 </div>


### PR DESCRIPTION
- Updated README with more details
- Only show links to archives when more then 3 posts exists. The home page only show up to three blog posts and the archives page would be redundant if there are less than 3 posts.